### PR TITLE
Set footer attribution link targets to blank and no follow

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -41,8 +41,8 @@
 			<div id="body-class" style="display: none;" class="{{body_class}}"></div>
 			<footer id="footer">
 				<section class="credits">
-					<span class="credits-theme">Theme <a href="https://github.com/zutrinken/bleak">Bleak</a> by <a href="http://zutrinken.com" rel="nofollow">zutrinken</a></span>
-					<span class="credits-software">Published with <a href="http://ghost.org">Ghost</a></span>
+					<span class="credits-theme">Theme <a href="https://github.com/zutrinken/bleak" target="_blank" rel="nofollow">Bleak</a> by <a href="http://zutrinken.com" target="_blank" rel="nofollow">zutrinken</a></span>
+					<span class="credits-software">Published with <a href="http://ghost.org" target="_blank" rel="nofollow">Ghost</a></span>
 				</section>
 			</footer>
 			{{#if @blog.navigation}}


### PR DESCRIPTION
Updated the attribution links so they open in a new tab and aren't followed in SEO 