### PR TITLE
Correct ajax reloading for disqus

### DIFF
--- a/src/js/script.js
+++ b/src/js/script.js
@@ -115,6 +115,16 @@ jQuery(function($) {
 				'display' : 'none'
 			});
 		} else {
+			if (window.DISQUS) {
+				return DISQUS.reset({
+					reload: true,
+					config: function () {
+						this.page.identifier = location.pathname;
+						this.page.url = location.origin + location.pathname;
+					}
+				});
+			}
+
 			$.ajax({
 				type: "GET",
 				url: "//" + disqus + ".disqus.com/embed.js",


### PR DESCRIPTION
Howdy!

Disqus wants to use `DISQUS.reset` on ajax sites instead of calling the `embed.js` multiple times: https://help.disqus.com/customer/portal/articles/472107-using-disqus-on-ajax-sites

This PR fixes the error by using `DISQUS.reset` and using `location.pathname` as well as `location.origin` to set the needed identifier and url.