### PR TITLE
fix inline code blocks in mobile because break layout

### DIFF
--- a/src/sass/style.scss
+++ b/src/sass/style.scss
@@ -242,7 +242,6 @@ tt {
 	font-family: 'Inconsolata', monospace;
 	font-size: 0.875em;
 	line-height: 1.143em;
-	white-space: pre;
 	background: $color-gray-90;
 	color: #000;
 	font-weight: 400;


### PR DESCRIPTION
fix inline code blocks in mobile because break layout

![bleak-issue3](https://user-images.githubusercontent.com/4282123/32689165-8b5da2f8-c6df-11e7-94b9-a5abf5ab6e3f.PNG)
