### PR TITLE
Fix code block scrollbar margin

### DIFF
--- a/src/sass/style.scss
+++ b/src/sass/style.scss
@@ -285,8 +285,8 @@ a {
 			display: block;
 			border: 0;
 			padding: 1.5em;
-			padding-left: 4em;
 			margin: -1em;
+			margin-left: 2em;
 			white-space: inherit;
 			overflow-x: auto;
 			background: $color-gray-90;


### PR DESCRIPTION
I noticed that in the code block part of the scrollbar is covered by the div containing line numbers.

![before](https://user-images.githubusercontent.com/1384600/34908883-dc84afb6-f897-11e7-88a8-c87a83c13dd1.PNG)

After the fix entire scrollbar is visible

![after](https://user-images.githubusercontent.com/1384600/34908884-e04800da-f897-11e7-84d2-222a17ed6060.PNG)

